### PR TITLE
tadeas/patch

### DIFF
--- a/semantic/mesh/roof/rectangular.cpp
+++ b/semantic/mesh/roof/rectangular.cpp
@@ -324,7 +324,7 @@ geometry::Mesh mesh(const roof::Rectangular &r, const MeshConfig &config
              , -useCurbBottom - skewBottomTan * (useCurbLeft - curbMiddle)
              , eaveHeight);
 
-        if (useCurbBottom == 1.0) {
+        if (useCurbLeft == 1.0) {
             deferred.face(4, 10, 8, Material::roof);
             deferred.face(4, 6, 10, Material::roof);
         } else {
@@ -360,7 +360,7 @@ geometry::Mesh mesh(const roof::Rectangular &r, const MeshConfig &config
              , -useCurbBottom + skewBottomTan * (useCurbRight + curbMiddle)
              , eaveHeight);
 
-        if (useCurbRight == 1.0) {
+        if (useCurbBottom == 1.0) {
             deferred.face(6, 11, 10, Material::roof);
             deferred.face(6, 7, 11, Material::roof);
         } else {

--- a/semantic/mesh/roof/rectangular.cpp
+++ b/semantic/mesh/roof/rectangular.cpp
@@ -374,6 +374,9 @@ geometry::Mesh mesh(const roof::Rectangular &r, const MeshConfig &config
     const auto hipTop(r.hip[+Key::top]);
     const auto hipBottom(r.hip[+Key::bottom]);
 
+    const auto totalCurbVertical((curbTop + curbBottom) / 2);
+    const auto curbMiddleVertical((curbBottom - curbTop) / 2);
+
     v[12] = c.point(-curbLeft
                     , curbTop - skewTopTan * (curbLeft - curbMiddle)
                     , r.curbHeight);
@@ -382,7 +385,9 @@ geometry::Mesh mesh(const roof::Rectangular &r, const MeshConfig &config
                     , curbTop + skewTopTan * (curbRight + curbMiddle)
                     , r.curbHeight);
 
-    v[14] = c.point(-curbMiddle, curbTop * hipTop, r.ridgeHeight);
+    v[14] = c.point(-curbMiddle
+                    , -curbMiddleVertical + hipTop * totalCurbVertical
+                    , r.ridgeHeight);
 
     v[15] = c.point(-curbLeft
                     , -curbBottom - skewBottomTan * (curbLeft - curbMiddle)
@@ -392,7 +397,9 @@ geometry::Mesh mesh(const roof::Rectangular &r, const MeshConfig &config
                     , -curbBottom + skewBottomTan * (curbRight + curbMiddle)
                     , r.curbHeight);
 
-    v[17] = c.point(-curbMiddle, -curbBottom * hipBottom, r.ridgeHeight);
+    v[17] = c.point(-curbMiddle,
+                    -curbMiddleVertical - hipBottom * totalCurbVertical,
+                    r.ridgeHeight);
 
     c.face(v, 8, 10, 12, Material::roof);
     c.face(v, 12, 10, 15, Material::roof);


### PR DESCRIPTION
Fixed two errors:
- The previous formula for the ridge length was wrong in some cases.
- Two conditions for splitting quadrangles into triangles were wrong (inverted).

Attached one previously erroneous input for each point.
[semantic2obj.zip](https://github.com/melowntech/libsemantic/files/4757575/semantic2obj.zip)
