### PR TITLE
Fix rounding in semantic2vef

### DIFF
--- a/semantic/mesh.hpp
+++ b/semantic/mesh.hpp
@@ -63,6 +63,10 @@ struct MeshConfig {
     /** Generate closed surface (solids)?
      */
     bool closedSurface = false;
+
+    /** Keep the mesh in world's CRS (i.e. do not shift by world origin)
+     */
+    bool worldCrs = false;
 };
 
 /** Generate mesh in given LOD.

--- a/semantic/mesh/mesh.cpp
+++ b/semantic/mesh/mesh.cpp
@@ -57,7 +57,9 @@ geometry::Mesh mesh(const roof::Roof &roof
 geometry::Mesh mesh(const Building &building, const MeshConfig &config
                     , const math::Point3 &origin_)
 {
-    const auto origin(origin_ + building.origin);
+    auto origin(building.origin);
+    // shift to world origin
+    if (!config.worldCrs) { origin += origin_; }
 
     geometry::Mesh m;
     if (!building.mesh.vertices.empty())

--- a/semantic/mesh/tree.cpp
+++ b/semantic/mesh/tree.cpp
@@ -165,7 +165,9 @@ geometry::Mesh mesh(const Tree &tree, const MeshConfig &config
     buildSphericalHarmonics(m, config, tree.harmonics
                             , treeCrownMaterial(tree));
 
-    const math::Point3 offset(origin + tree.origin + tree.center);
+    math::Point3 offset(tree.origin + tree.center);
+    // shift to world origin if not local crs
+    if (!config.worldCrs) { offset += origin; }
     for (auto &v : m.vertices) {
         v(0) = v(0) * tree.a + offset(0);
         v(1) = v(1) * tree.a + offset(1);
@@ -173,7 +175,9 @@ geometry::Mesh mesh(const Tree &tree, const MeshConfig &config
     }
 
     // add tree trunk
-    trunk(m, tree, config, origin + tree.origin, treeTrunkMaterial(tree));
+    math::Point3 trunkOrigin(tree.origin);
+    if (!config.worldCrs) { trunkOrigin += origin; }
+    trunk(m, tree, config, trunkOrigin, treeTrunkMaterial(tree));
 
     return m;
 }

--- a/semantic/tools/semantic2vef.cpp
+++ b/semantic/tools/semantic2vef.cpp
@@ -183,6 +183,8 @@ int Semantic2Vef::run()
     boost::optional<geo::SrsDefinition> srs;
     cv::Mat3b txtImg = createTextureImg(txtColorWidth_);
 
+    meshConfig_.worldCrs = true;
+
     geometry::Mesh mesh;
     for (const auto &input : input_) {
         // load world
@@ -205,7 +207,12 @@ int Semantic2Vef::run()
             windowName = input.parent_path().filename().string();
         }
 
-        vef::Id winId = ar.addWindow(windowName, boost::none);
+        math::Matrix4 worldTf(math::identity4());
+        worldTf(0, 3) = world.origin(0);
+        worldTf(1, 3) = world.origin(1);
+        worldTf(2, 3) = world.origin(2);
+
+        vef::Id winId = ar.addWindow(windowName, worldTf);
         vef::Id lodId = ar.addLod(winId);
 
         // save texture


### PR DESCRIPTION
Meshes exported by `semantic2vef` tool contained artifacts connected to rounding after transformation to the global CRS.

This PR changes `semantic2vef` so that it saves meshes in the local coordinate system of a semantic world. The transformation to the global coordinate system is moved to the window specification inside vef.