### PR TITLE
Fixing colinearity computation

### DIFF
--- a/semantic/mesh/detail.hpp
+++ b/semantic/mesh/detail.hpp
@@ -73,7 +73,7 @@ inline math::Point3 rotate(const math::Point3 &p, double angle)
 inline bool colinear(double a, double b, double c, double t)
 {
     // Interpolate expected height on line from a to c
-    const auto expected(t * a + (1 - t) * c);
+    const auto expected((1 - t) * a + t * c);
 
     // Compare with provided height b
     return (std::abs(expected - b) < 1e-5);


### PR DESCRIPTION
Fixing collinearity fcn - `expected` is between `(0, a)` and `(1, c)` i.e. when `t=0`, `expected=a` and `t=1` `expected=c` - this corresponds to formula: `expected=(1 - t) * a + t * c`.